### PR TITLE
Fix: Refactor VoiceRoom type definition to resolve SWC parsing error

### DIFF
--- a/src/hooks/useVoiceCollaboration.ts
+++ b/src/hooks/useVoiceCollaboration.ts
@@ -25,8 +25,12 @@ interface Participant {
   role?: string;
 }
 
-interface VoiceRoom extends Database['public']['Tables']['voice_rooms']['Row'] {
-  participant_count?: number; // Add this field as it's used by the hook
+// Define an alias for the Row type
+type VoiceRoomRow = Database['public']['Tables']['voice_rooms']['Row'];
+
+// Extend the alias
+interface VoiceRoom extends VoiceRoomRow {
+  participant_count?: number;
 }
 
 interface SandboxTokenDetails {

--- a/src/services/voiceRoomService.ts
+++ b/src/services/voiceRoomService.ts
@@ -2,7 +2,11 @@
 import { supabase } from '@/integrations/supabase/client';
 import type { Database } from '../lib/database.types';
 
-export interface VoiceRoom extends Database['public']['Tables']['voice_rooms']['Row'] {
+// Define an alias for the Row type
+type VoiceRoomRow = Database['public']['Tables']['voice_rooms']['Row'];
+
+// Extend the alias
+export interface VoiceRoom extends VoiceRoomRow {
   participant_count?: number;
 }
 


### PR DESCRIPTION
This commit addresses a syntax error "Expected ',', got '['" reported by the SWC compiler in Vite when processing the VoiceRoom interface definition in `src/hooks/useVoiceCollaboration.ts`.

The error occurred due to the direct use of a complex indexed access type (`Database['public']['Tables']['voice_rooms']['Row']`) in the `extends` clause.

Changes:
- In `src/hooks/useVoiceCollaboration.ts`:
    - Introduced a type alias `VoiceRoomRow = Database['public']['Tables']['voice_rooms']['Row'];`.
    - Modified the `VoiceRoom` interface to extend this `VoiceRoomRow` alias (`interface VoiceRoom extends VoiceRoomRow { ... }`).
- In `src/services/voiceRoomService.ts`:
    - Applied the same refactoring strategy to its `VoiceRoom` interface definition for consistency and to prevent potential similar issues.

This refactoring simplifies the type expression in the `extends` clause, which is expected to resolve the SWC parsing error and allow the application to compile successfully.