### PR TITLE
Fix: Use type alias for VoiceRoom definitions

### DIFF
--- a/src/hooks/useVoiceCollaboration.ts
+++ b/src/hooks/useVoiceCollaboration.ts
@@ -28,10 +28,10 @@ interface Participant {
 // Define an alias for the Row type
 type VoiceRoomRow = Database['public']['Tables']['voice_rooms']['Row'];
 
-// Extend the alias
-interface VoiceRoom extends VoiceRoomRow {
+// Use a type alias with an intersection type
+type VoiceRoom = VoiceRoomRow & {
   participant_count?: number;
-}
+};
 
 interface SandboxTokenDetails {
   serverUrl: string;

--- a/src/services/voiceRoomService.ts
+++ b/src/services/voiceRoomService.ts
@@ -5,10 +5,10 @@ import type { Database } from '../lib/database.types';
 // Define an alias for the Row type
 type VoiceRoomRow = Database['public']['Tables']['voice_rooms']['Row'];
 
-// Extend the alias
-export interface VoiceRoom extends VoiceRoomRow {
+// Use an exported type alias with an intersection type
+export type VoiceRoom = VoiceRoomRow & {
   participant_count?: number;
-}
+};
 
 export interface VoiceRoomParticipant {
   id: string;


### PR DESCRIPTION
I changed the VoiceRoom interface to a type alias using an intersection in both `useVoiceCollaboration.ts` and `voiceRoomService.ts`.

This change is an attempt to resolve persistent syntax errors that might be due to subtle parsing issues with the previous interface extension method. Using a type alias with an intersection is an alternative way to achieve the same type structure and may work around such parsing problems.