### PR TITLE
Fix: Address multiple runtime and Supabase errors

### DIFF
--- a/src/hooks/useVoiceCollaboration.ts
+++ b/src/hooks/useVoiceCollaboration.ts
@@ -204,7 +204,7 @@ export const useVoiceCollaboration = ({
       try {
         const { data, error: fetchError } = await supabase
           .from('voice_rooms')
-          .select('*, participant_count:voice_room_participants(count)') // Assuming you might want participant count
+          .select('*')
           .eq('match_id', matchId)
           .eq('is_active', true);
         

--- a/src/services/AudioManager.ts
+++ b/src/services/AudioManager.ts
@@ -27,4 +27,20 @@ export class AudioManager {
     // Placeholder implementation
     console.warn('[AudioManager Placeholder] removeRemoteStream called - using placeholder implementation');
   }
+
+  public async getAudioOutputDevices(): Promise<MediaDeviceInfo[]> {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
+      console.error('enumerateDevices() not supported.');
+      return [];
+    }
+
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      const audioOutputDevices = devices.filter(device => device.kind === 'audiooutput');
+      return audioOutputDevices;
+    } catch (err) {
+      console.error('Error enumerating audio output devices:', err);
+      return [];
+    }
+  }
 }


### PR DESCRIPTION
This commit includes several fixes and workarounds for issues identified from console error logs:

1.  **Fix(AudioManager): Implement getAudioOutputDevices**
    - I added the `getAudioOutputDevices` method to `src/services/AudioManager.ts`.
    - This resolves a `TypeError` caused by this method being missing from the placeholder implementation.
    - The method now correctly uses `navigator.mediaDevices.enumerateDevices()` to list and filter audio output devices.

2.  **Workaround(VoiceCollaboration): Simplify voice_rooms query to prevent 500 error**
    - I modified `src/hooks/useVoiceCollaboration.ts` to change the Supabase query for fetching voice rooms from `select('*, participant_count:voice_room_participants(count)')` to `select('*')`.
    - This is a workaround to prevent a 500 Internal Server Error from Supabase, likely caused by complexity or RLS issues with the participant count sub-query.

3.  **Chore(App): Confirm resilience in real-time match updates**
    - I reviewed the real-time match update handling in `src/App.tsx`.
    - I confirmed that the existing code already gracefully handles potentially missing `name`, `home_team_name`, and `away_team_name` fields in the payload from Supabase real-time updates (related to 406 errors on specific match queries). No code changes were needed here.

4.  **Chore(Hooks): Investigate React Error #299**
    - I investigated key components and hooks for conditional hook calls. I found no direct violations in the inspected files. This error may require further targeted debugging if it persists.

5.  **Chore: Review 'Cannot redefine property' TypeError**
    - I acknowledged this error, which is often external (e.g., browser extensions) or a side-effect of other runtime issues. It may be mitigated by the above fixes.