### PR TITLE
Fix: Address follow-up issues in voice room and data fetching

### DIFF
--- a/supabase/functions/join-voice-room/index.ts
+++ b/supabase/functions/join-voice-room/index.ts
@@ -96,7 +96,10 @@ async function handleJoinRoom(supabaseClient: SupabaseClient, roomId: string, us
 
   const { error: participantError } = await supabaseClient
     .from('voice_room_participants')
-    .upsert(participantData) // Use upsert to handle re-joining
+    .upsert(participantData, {
+      onConflict: 'room_id,user_id',
+      ignoreDuplicates: false // Ensure it updates on conflict
+    })
 
   if (participantError) {
     console.error('Error upserting participant:', participantError.message)

--- a/supabase/migrations/20250607170928_create_realtime_transient_messages_table.sql
+++ b/supabase/migrations/20250607170928_create_realtime_transient_messages_table.sql
@@ -1,0 +1,59 @@
+CREATE TABLE realtime_transient_messages (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+    room_id UUID NOT NULL,
+    sender_id UUID NOT NULL,
+    to_user_id UUID NULL, -- Nullable for broadcast messages
+    message_type TEXT NOT NULL,
+    payload JSONB NULL,
+    CONSTRAINT fk_room FOREIGN KEY (room_id) REFERENCES voice_rooms(id) ON DELETE CASCADE,
+    CONSTRAINT fk_sender FOREIGN KEY (sender_id) REFERENCES profiles(id) ON DELETE CASCADE,
+    CONSTRAINT fk_receiver FOREIGN KEY (to_user_id) REFERENCES profiles(id) ON DELETE SET NULL -- Optional: if receiver is deleted, set to_user_id to NULL
+);
+
+-- Add indexes for common query patterns
+CREATE INDEX idx_realtime_transient_messages_room_id ON realtime_transient_messages(room_id);
+CREATE INDEX idx_realtime_transient_messages_created_at ON realtime_transient_messages(created_at);
+
+-- Enable RLS
+ALTER TABLE realtime_transient_messages ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policy: Allow users to insert messages if they are the sender
+CREATE POLICY "Users can insert their own messages"
+ON realtime_transient_messages
+FOR INSERT
+WITH CHECK (sender_id = auth.uid());
+
+-- RLS Policy: Allow users to select messages intended for them, or broadcast messages in their rooms, or messages they sent
+-- This policy relies on users being able to listen to postgres_changes on this table,
+-- which is governed by the publication, but RLS still applies for direct SELECTs.
+-- For Realtime, the key is that the user's role has SELECT privileges on the table,
+-- and the `supabase_realtime` publication includes the table.
+CREATE POLICY "Users can select relevant messages"
+ON realtime_transient_messages
+FOR SELECT
+USING (
+    -- User is the sender
+    sender_id = auth.uid() OR
+    -- User is the direct recipient
+    to_user_id = auth.uid() OR
+    -- Message is a broadcast (to_user_id is NULL) AND user is part of that room
+    (
+        to_user_id IS NULL AND
+        EXISTS (
+            SELECT 1 FROM voice_room_participants vrp
+            WHERE vrp.room_id = realtime_transient_messages.room_id
+            AND vrp.user_id = auth.uid()
+        )
+    )
+);
+
+-- Grant usage on sequence for id column if using BIGSERIAL and RLS (for insert)
+-- This might be needed if RLS prevents default from working. Usually Supabase handles this.
+-- GRANT USAGE, SELECT ON SEQUENCE realtime_transient_messages_id_seq TO authenticated;
+
+-- Ensure the table is part of the supabase_realtime publication
+-- This is usually handled automatically by Supabase when enabling Realtime for a table,
+-- but can be made explicit if issues arise.
+-- Example (run by an admin if needed, might not be necessary in migration):
+-- ALTER PUBLICATION supabase_realtime ADD TABLE realtime_transient_messages;

--- a/supabase/migrations/20250607171118_alter_get_user_role_function_default.sql
+++ b/supabase/migrations/20250607171118_alter_get_user_role_function_default.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION public.get_user_role(p_user_id UUID)
+RETURNS TEXT
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, auth, extensions
+AS $$
+-- Description: Retrieves the role of a user based on the p_user_id.
+--              The role is expected to be stored in the raw_app_meta_data->>'role'
+--              field of the auth.users table. Defaults to 'user' if no role is set or user not found.
+SELECT COALESCE(
+    (SELECT raw_app_meta_data ->> 'role'
+     FROM auth.users
+     WHERE id = p_user_id),
+    'user' -- Default role if not found or NULL
+);
+$$;
+
+COMMENT ON FUNCTION public.get_user_role(UUID)
+IS 'Retrieves the role of a user from auth.users.raw_app_meta_data, defaulting to ''user''. SECURITY DEFINER.';
+
+-- Ensure permissions are still granted
+GRANT EXECUTE ON FUNCTION public.get_user_role(UUID) TO authenticated;


### PR DESCRIPTION
This commit addresses several issues identified from further user feedback and logs, following the initial voice room fixes:

1.  **Duplicate Key Error in `join-voice-room`:**
    - Modified the `upsert` operation in the `supabase/functions/join-voice-room/index.ts` Edge Function.
    - Added `onConflict: 'room_id,user_id'` to ensure that if a participant record already exists for the given room_id and user_id, it gets updated instead of causing a duplicate key error. This resolves issues with you rejoining rooms or multiple join attempts.

2.  **404 Error for `realtime_transient_messages` (WebRTC Signaling):**
    - Created a new database migration (`supabase/migrations/<timestamp>_create_realtime_transient_messages_table.sql`) to define the `realtime_transient_messages` table.
    - This table is essential for the custom WebRTC signaling mechanism used by `WebRTCManager.ts`.
    - The migration includes table schema, indexes, foreign key constraints, and Row Level Security (RLS) policies for inserting and selecting signaling messages.
    - This should resolve the 404 errors when the client attempts to send or listen for signaling messages.

3.  **Potential 406 Error for `matches` Table:**
    - Created a new database migration (`supabase/migrations/<timestamp>_alter_get_user_role_function_default.sql`) to alter the `public.get_user_role(UUID)` function.
    - The function now defaults to returning 'user' if a role is not found in `auth.users.raw_app_meta_data`.
    - This ensures that RLS policies for the `matches` table, which use this function, always receive a non-NULL role. This is a precautionary measure to eliminate a potential variable that could contribute to unexpected errors like 406 during data fetching, by making the RLS evaluation more robust.

These changes aim to improve the stability and functionality of the voice collaboration features and data retrieval.