### PR TITLE
feat: Implement new voice chat collaboration feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import LandingPage from "./pages/LandingPage";
 import MatchTimerPage from "./pages/MatchTimerPage";
 import VideoAnalysis from "./pages/VideoAnalysis";
 import Settings from "./pages/Settings";
+import NewVoiceChatPage from '@/pages/NewVoiceChatPage'; // Adjust path as needed
 import Header from "./components/Header";
 import { useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
@@ -121,6 +122,7 @@ const AppContent = () => {
             </RequireAuth>
           } 
         />
+        <Route path="/new-voice-chat" element={<NewVoiceChatPage />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/src/components/voice/NewVoiceChat.test.tsx
+++ b/src/components/voice/NewVoiceChat.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom'; // For extended DOM matchers
+import { NewVoiceChat } from './NewVoiceChat';
+import { useNewVoiceCollaboration, UseNewVoiceCollaborationReturn } from '@/hooks/useNewVoiceCollaboration';
+import { ConnectionState, Participant } from 'livekit-client';
+
+// Mock the custom hook
+jest.mock('@/hooks/useNewVoiceCollaboration');
+
+const mockUseNewVoiceCollaboration = useNewVoiceCollaboration as jest.MockedFunction<typeof useNewVoiceCollaboration>;
+
+// Default mock state for the hook
+const getDefaultMockHookState = (): UseNewVoiceCollaborationReturn => ({
+  manager: null,
+  availableRooms: [],
+  currentRoomId: null,
+  participants: [],
+  localParticipant: null,
+  connectionState: ConnectionState.Disconnected,
+  isConnecting: false,
+  isConnected: false,
+  isLoadingRooms: false,
+  error: null,
+  joinRoom: jest.fn().mockResolvedValue(true),
+  leaveRoom: jest.fn().mockResolvedValue(undefined),
+  toggleMuteSelf: jest.fn().mockResolvedValue(true),
+  fetchAvailableRooms: jest.fn().mockResolvedValue(undefined),
+  moderateMuteParticipant: jest.fn().mockResolvedValue(true),
+});
+
+describe('NewVoiceChat Component', () => {
+  let mockHookState: UseNewVoiceCollaborationReturn;
+
+  beforeEach(() => {
+    // Reset mocks and provide a fresh default state for each test
+    mockHookState = getDefaultMockHookState();
+    mockUseNewVoiceCollaboration.mockReturnValue(mockHookState);
+    jest.clearAllMocks(); // Clear all mock function calls
+  });
+
+  it('should render initial state correctly (disconnected, no rooms)', () => {
+    render(<NewVoiceChat />);
+    expect(screen.getByText('New Voice Chat')).toBeInTheDocument();
+    expect(screen.getByText(/Connection State: Disconnected/i)).toBeInTheDocument();
+    expect(screen.getByText(/No rooms available/i)).toBeInTheDocument();
+    // Check for input fields for user/match details (part of the test setup in the component)
+    expect(screen.getByLabelText(/Match ID:/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/User ID:/i)).toBeInTheDocument();
+  });
+
+  it('should display "Loading rooms..." when isLoadingRooms is true', () => {
+    mockUseNewVoiceCollaboration.mockReturnValue({ ...mockHookState, isLoadingRooms: true });
+    render(<NewVoiceChat />);
+    expect(screen.getByText('Loading rooms...')).toBeInTheDocument();
+  });
+
+  it('should display an error message when error is present', () => {
+    const testError = new Error("Failed to connect");
+    mockUseNewVoiceCollaboration.mockReturnValue({ ...mockHookState, error: testError });
+    render(<NewVoiceChat />);
+    expect(screen.getByText(`Error: ${testError.message}`)).toBeInTheDocument();
+  });
+
+  it('should call fetchAvailableRooms on "Refresh Rooms" button click', async () => {
+    render(<NewVoiceChat />);
+    const matchIdInput = screen.getByLabelText(/Match ID:/i) as HTMLInputElement;
+    fireEvent.change(matchIdInput, { target: { value: 'test-match-1' } });
+
+    const refreshButton = screen.getByRole('button', { name: /Refresh Rooms/i });
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(mockHookState.fetchAvailableRooms).toHaveBeenCalledWith('test-match-1');
+    });
+  });
+
+  it('should list available rooms and allow joining', async () => {
+    mockHookState.availableRooms = [{ id: 'room1', name: 'Test Room 1' }];
+    mockUseNewVoiceCollaboration.mockReturnValue(mockHookState);
+
+    render(<NewVoiceChat />);
+
+    expect(screen.getByText('Test Room 1 (ID: room1)')).toBeInTheDocument();
+    const joinButton = screen.getByRole('button', { name: /Join/i });
+
+    // Set user details for joining
+    const userIdInput = screen.getByLabelText(/User ID:/i) as HTMLInputElement;
+    const userRoleInput = screen.getByLabelText(/User Role:/i) as HTMLInputElement;
+    const userNameInput = screen.getByLabelText(/User Name:/i)as HTMLInputElement;
+    fireEvent.change(userIdInput, { target: { value: 'testUser123' } });
+    fireEvent.change(userRoleInput, { target: { value: 'tester' } });
+    fireEvent.change(userNameInput, { target: { value: 'Test User Name' } });
+
+    fireEvent.click(joinButton);
+
+    await waitFor(() => {
+      expect(mockHookState.joinRoom).toHaveBeenCalledWith('room1', 'testUser123', 'tester', 'Test User Name');
+    });
+  });
+
+  it('should show alert if user ID or role is missing when trying to join', () => {
+    jest.spyOn(window, 'alert').mockImplementation(() => {}); // Mock window.alert
+    mockHookState.availableRooms = [{ id: 'room1', name: 'Test Room 1' }];
+    mockUseNewVoiceCollaboration.mockReturnValue(mockHookState);
+
+    render(<NewVoiceChat />);
+    const joinButton = screen.getByRole('button', { name: /Join/i });
+
+    // Clear user ID to trigger alert
+    const userIdInput = screen.getByLabelText(/User ID:/i) as HTMLInputElement;
+    fireEvent.change(userIdInput, { target: { value: '' } });
+
+    fireEvent.click(joinButton);
+
+    expect(window.alert).toHaveBeenCalledWith("User ID and Role are required to join a room.");
+    expect(mockHookState.joinRoom).not.toHaveBeenCalled();
+    (window.alert as jest.Mock).mockRestore(); // Clean up mock
+  });
+
+
+  describe('When Connected to a Room', () => {
+    beforeEach(() => {
+      const localP = { identity: 'localUser', name: 'You', isLocal: true, isMicrophoneMuted: false, isSpeaking: false } as unknown as Participant;
+      const remoteP = { identity: 'remoteUser1', name: 'Remote 1', isLocal: false, isMicrophoneMuted: false, isSpeaking: true } as unknown as Participant;
+
+      mockHookState.isConnected = true;
+      mockHookState.currentRoomId = 'room-alpha';
+      mockHookState.participants = [localP, remoteP];
+      mockHookState.localParticipant = localP;
+      mockHookState.connectionState = ConnectionState.Connected;
+      mockUseNewVoiceCollaboration.mockReturnValue(mockHookState);
+    });
+
+    it('should display connected state, room ID, and participants', () => {
+      render(<NewVoiceChat />);
+      expect(screen.getByText('In Room: room-alpha')).toBeInTheDocument();
+      expect(screen.getByText('You (You)')).toBeInTheDocument();
+      expect(screen.getByText('Remote 1 (Speaking)')).toBeInTheDocument(); // (Speaking) should be appended
+      expect(screen.getByRole('button', { name: /Leave Room/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Mute Self/i })).toBeInTheDocument();
+    });
+
+    it('should call leaveRoom when "Leave Room" is clicked', async () => {
+      render(<NewVoiceChat />);
+      fireEvent.click(screen.getByRole('button', { name: /Leave Room/i }));
+      await waitFor(() => {
+        expect(mockHookState.leaveRoom).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should call toggleMuteSelf and update button text when "Mute Self" / "Unmute Self" is clicked', async () => {
+      render(<NewVoiceChat />);
+      const muteButton = screen.getByRole('button', { name: /Mute Self/i });
+      fireEvent.click(muteButton);
+
+      await waitFor(() => {
+        expect(mockHookState.toggleMuteSelf).toHaveBeenCalledTimes(1);
+      });
+
+      // Simulate participant state update after toggle
+      const updatedLocalParticipant = { ...mockHookState.localParticipant!, isMicrophoneMuted: true };
+      mockUseNewVoiceCollaboration.mockReturnValue({
+        ...mockHookState,
+        localParticipant: updatedLocalParticipant,
+        participants: [updatedLocalParticipant, ...mockHookState.participants.filter(p => !p.isLocal)]
+      });
+
+      // Re-render or update (testing-library handles re-renders on state change if hook behaves so)
+      // For this test, we directly check the mocked function and can assume the text changes if localParticipant state updates.
+      // To explicitly test text change, you'd need to re-render with new hook state.
+      // Let's verify the button text would change if the localParticipant state updates:
+      render(<NewVoiceChat />); // Re-render with the new state from the mock hook
+      expect(screen.getByRole('button', { name: /Unmute Self/i })).toBeInTheDocument();
+    });
+
+    it('should display (Muted) next to a muted participant', () => {
+      const mutedLocalP = { ...mockHookState.localParticipant!, isMicrophoneMuted: true };
+      mockUseNewVoiceCollaboration.mockReturnValue({
+          ...mockHookState,
+          localParticipant: mutedLocalP,
+          participants: [mutedLocalP, ...mockHookState.participants.filter(p => !p.isLocal)]
+      });
+      render(<NewVoiceChat />);
+      expect(screen.getByText('You (You) (Muted)')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/voice/NewVoiceChat.tsx
+++ b/src/components/voice/NewVoiceChat.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from 'react';
+import { useNewVoiceCollaboration } from '@/hooks/useNewVoiceCollaboration'; // Adjust path as needed
+import { Participant, ConnectionState } from 'livekit-client';
+
+// Basic styling (inline for simplicity, consider moving to CSS modules or a UI library)
+const styles = {
+  container: { fontFamily: 'Arial, sans-serif', padding: '20px', maxWidth: '600px', margin: '0 auto' },
+  header: { fontSize: '24px', marginBottom: '20px' },
+  section: { marginBottom: '20px', padding: '10px', border: '1px solid #eee', borderRadius: '5px' },
+  roomList: { listStyle: 'none', padding: '0' },
+  roomItem: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 0', borderBottom: '1px solid #f0f0f0' },
+  participantList: { listStyle: 'none', padding: '0' },
+  participantItem: { padding: '5px 0', color: '#555' },
+  button: { padding: '8px 12px', marginRight: '10px', cursor: 'pointer', border: 'none', borderRadius: '4px', backgroundColor: '#007bff', color: 'white' },
+  error: { color: 'red', marginTop: '10px' },
+  info: { color: 'blue', marginTop: '10px' },
+  input: { padding: '8px', marginRight: '10px', borderRadius: '4px', border: '1px solid #ccc' }
+};
+
+// Mock user data - replace with actual user data from your auth context or props
+// Ensure you have a way to get the current user's ID, role, and a display name.
+const MOCK_USER = {
+  id: `user-${Math.random().toString(36).substring(7)}`, // Replace with actual user ID
+  role: 'tracker', // Replace with actual user role
+  name: `User ${Math.floor(Math.random() * 1000)}` // Replace with actual user name
+};
+
+// Mock match ID - replace with actual match ID from context or props
+const MOCK_MATCH_ID = 'match-123'; // Replace with actual match ID
+
+export const NewVoiceChat: React.FC = () => {
+  const {
+    availableRooms,
+    currentRoomId,
+    participants,
+    localParticipant,
+    connectionState,
+    isConnecting,
+    isConnected,
+    isLoadingRooms,
+    error,
+    joinRoom,
+    leaveRoom,
+    toggleMuteSelf,
+    fetchAvailableRooms,
+    // moderateMuteParticipant, // Example for future use
+  } = useNewVoiceCollaboration();
+
+  const [userIdInput, setUserIdInput] = useState<string>(MOCK_USER.id);
+  const [userRoleInput, setUserRoleInput] = useState<string>(MOCK_USER.role);
+  const [userNameInput, setUserNameInput] = useState<string>(MOCK_USER.name);
+  const [matchIdInput, setMatchIdInput] = useState<string>(MOCK_MATCH_ID);
+
+  useEffect(() => {
+    // Fetch rooms when component mounts, if a matchId is available
+    // In a real app, matchId might come from props or context
+    if (matchIdInput) {
+      fetchAvailableRooms(matchIdInput);
+    }
+  }, [fetchAvailableRooms, matchIdInput]);
+
+  const handleJoinRoom = async (roomId: string) => {
+    if (!userIdInput || !userRoleInput) {
+      alert("User ID and Role are required to join a room.");
+      return;
+    }
+    await joinRoom(roomId, userIdInput, userRoleInput, userNameInput);
+  };
+
+  const renderConnectionState = () => {
+    if (error) return <p style={styles.error}>Error: {error.message}</p>;
+    if (isConnecting) return <p style={styles.info}>Connecting...</p>;
+    if (isConnected) return <p style={styles.info}>Connected to room: {currentRoomId}</p>;
+    if (connectionState === ConnectionState.Disconnected && currentRoomId) {
+      // This case might occur if disconnected unexpectedly AFTER being in a room
+      return <p style={styles.info}>Disconnected. Was in room: {currentRoomId}</p>;
+    }
+    if (connectionState === ConnectionState.Disconnected) return <p style={styles.info}>Disconnected</p>;
+    return <p style={styles.info}>Connection State: {connectionState ?? 'Initializing...'}</p>;
+  };
+
+  return (
+    <div style={styles.container}>
+      <h1 style={styles.header}>New Voice Chat</h1>
+
+      {/* User and Match ID Inputs - For testing; replace with actual context/props */}
+      <div style={styles.section}>
+        <h3>Configuration (Test Only)</h3>
+        <div>
+          <label>Match ID: </label>
+          <input type="text" value={matchIdInput} onChange={(e) => setMatchIdInput(e.target.value)} style={styles.input} />
+          <button onClick={() => fetchAvailableRooms(matchIdInput)} style={styles.button} disabled={isLoadingRooms || !matchIdInput}>
+            {isLoadingRooms ? 'Loading Rooms...' : 'Refresh Rooms'}
+          </button>
+        </div>
+        <div>
+          <label>User ID: </label>
+          <input type="text" value={userIdInput} onChange={(e) => setUserIdInput(e.target.value)} style={styles.input} />
+        </div>
+        <div>
+          <label>User Role: </label>
+          <input type="text" value={userRoleInput} onChange={(e) => setUserRoleInput(e.target.value)} style={styles.input} />
+        </div>
+        <div>
+          <label>User Name: </label>
+          <input type="text" value={userNameInput} onChange={(e) => setUserNameInput(e.target.value)} style={styles.input} />
+        </div>
+      </div>
+
+      {renderConnectionState()}
+
+      {!isConnected && !isConnecting && (
+        <div style={styles.section}>
+          <h2>Available Rooms</h2>
+          {isLoadingRooms && <p>Loading rooms...</p>}
+          {!isLoadingRooms && availableRooms.length === 0 && <p>No rooms available for this match or failed to load.</p>}
+          <ul style={styles.roomList}>
+            {availableRooms.map(room => (
+              <li key={room.id} style={styles.roomItem}>
+                <span>{room.name} (ID: {room.id})</span>
+                <button onClick={() => handleJoinRoom(room.id)} style={styles.button} disabled={!userIdInput || !userRoleInput}>Join</button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {isConnected && currentRoomId && (
+        <div style={styles.section}>
+          <h2>In Room: {currentRoomId}</h2>
+          <button onClick={leaveRoom} style={styles.button}>Leave Room</button>
+          <button onClick={toggleMuteSelf} style={styles.button}>
+            {localParticipant?.isMicrophoneMuted ? 'Unmute Self' : 'Mute Self'}
+          </button>
+
+          <h3>Participants ({participants.length})</h3>
+          <ul style={styles.participantList}>
+            {participants.map(p => (
+              <li key={p.identity} style={styles.participantItem}>
+                {p.name || p.identity}
+                {p.isLocal && ' (You)'}
+                {p.isMicrophoneMuted && ' (Muted)'}
+                {p.isSpeaking && ' (Speaking)'}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// For actual usage, you would import this component and place it in your app structure.
+// e.g., in a page component:
+// import { NewVoiceChat } from '@/components/voice/NewVoiceChat';
+// const MyPage = () => <NewVoiceChat />;

--- a/src/hooks/useNewVoiceCollaboration.test.tsx
+++ b/src/hooks/useNewVoiceCollaboration.test.tsx
@@ -1,0 +1,265 @@
+import { renderHook, act } from '@testing-library/react-hooks'; // Or @testing-library/react
+import { useNewVoiceCollaboration } from './useNewVoiceCollaboration';
+import { NewVoiceChatManager } from '@/services/NewVoiceChatManager';
+import { ConnectionState, Participant } from 'livekit-client';
+
+// Mock the NewVoiceChatManager service
+jest.mock('@/services/NewVoiceChatManager');
+
+const mockManagerInstance = {
+  listAvailableRooms: jest.fn(),
+  joinRoom: jest.fn(),
+  leaveRoom: jest.fn(),
+  toggleMuteSelf: jest.fn(),
+  moderateMuteParticipant: jest.fn(),
+  dispose: jest.fn(),
+  getLocalParticipant: jest.fn(),
+  getCurrentRoomId: jest.fn(),
+  // Mocked callback setters
+  onParticipantsChanged: null as ((participants: Participant[]) => void) | null,
+  onConnectionStateChanged: null as ((state: ConnectionState) => void) | null,
+  onError: null as ((error: Error) => void) | null,
+};
+
+describe('useNewVoiceCollaboration Hook', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+
+    // Configure the NewVoiceChatManager mock constructor to return our controlled instance
+    (NewVoiceChatManager as jest.Mock).mockImplementation(() => {
+      // Assign callbacks to the mock instance so we can simulate them
+      // This part is tricky as the hook assigns these. We need to capture them.
+      // A better way might be to have the mockManagerInstance itself have properties for these callbacks
+      // that the hook's effect then sets.
+      // For this test, we'll assume the hook correctly sets these on the instance it creates.
+      // The mock instance will store the callbacks passed to it by the hook.
+      const instance = { ...mockManagerInstance };
+      Object.defineProperty(instance, 'onParticipantsChanged', {
+        configurable: true, writable: true, value: null,
+      });
+      Object.defineProperty(instance, 'onConnectionStateChanged', {
+        configurable: true, writable: true, value: null,
+      });
+      Object.defineProperty(instance, 'onError', {
+        configurable: true, writable: true, value: null,
+      });
+      return instance;
+    });
+  });
+
+  it('should initialize NewVoiceChatManager and set up callbacks', () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    expect(NewVoiceChatManager).toHaveBeenCalledTimes(1);
+    expect(result.current.manager).toBeDefined();
+
+    // Check if callbacks were set up (i.e., the manager's setters were called by the hook)
+    // This requires the mockManagerInstance to have been returned by the NewVoiceChatManager mock constructor
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+    expect(typeof managerInstanceInHook.onParticipantsChanged).toBe('function');
+    expect(typeof managerInstanceInHook.onConnectionStateChanged).toBe('function');
+    expect(typeof managerInstanceInHook.onError).toBe('function');
+  });
+
+  it('should call manager.dispose on unmount', () => {
+    const { unmount } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+
+    unmount();
+    expect(managerInstanceInHook.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should update participants when onParticipantsChanged is called', () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+
+    const mockParticipants = [{ identity: 'user1' } as Participant];
+    act(() => {
+      managerInstanceInHook.onParticipantsChanged(mockParticipants);
+    });
+    expect(result.current.participants).toEqual(mockParticipants);
+  });
+
+  it('should update connectionState when onConnectionStateChanged is called', () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+
+    managerInstanceInHook.getCurrentRoomId.mockReturnValue('room-123'); // Simulate manager has a room ID
+
+    act(() => {
+      managerInstanceInHook.onConnectionStateChanged(ConnectionState.Connected);
+    });
+    expect(result.current.connectionState).toBe(ConnectionState.Connected);
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.currentRoomId).toBe('room-123'); // Also check if currentRoomId is updated
+  });
+
+  it('should clear error when connected', () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+
+    act(() => {
+        managerInstanceInHook.onError(new Error("Initial error"));
+    });
+    expect(result.current.error).not.toBeNull();
+
+    act(() => {
+      managerInstanceInHook.onConnectionStateChanged(ConnectionState.Connected);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+
+  it('should update error when onError is called', () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+    const mockError = new Error('Test Error');
+
+    act(() => {
+      managerInstanceInHook.onError(mockError);
+    });
+    expect(result.current.error).toBe(mockError);
+  });
+
+  it('fetchAvailableRooms should call manager.listAvailableRooms and update state', async () => {
+    const { result, waitForNextUpdate } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+
+    const mockRoomsData = [{ id: 'room1', name: 'Room 1' }];
+    managerInstanceInHook.listAvailableRooms.mockResolvedValue(mockRoomsData);
+
+    await act(async () => {
+      result.current.fetchAvailableRooms('match1');
+    });
+
+    expect(managerInstanceInHook.listAvailableRooms).toHaveBeenCalledWith('match1');
+    expect(result.current.availableRooms).toEqual(mockRoomsData);
+    expect(result.current.isLoadingRooms).toBe(false);
+  });
+
+  it('fetchAvailableRooms should handle errors', async () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+    const mockError = new Error("Failed to fetch rooms");
+    managerInstanceInHook.listAvailableRooms.mockRejectedValue(mockError);
+
+    await act(async () => {
+      await result.current.fetchAvailableRooms('match1');
+    });
+
+    expect(result.current.error).toBe(mockError);
+    expect(result.current.isLoadingRooms).toBe(false);
+    expect(result.current.availableRooms).toEqual([]);
+  });
+
+
+  it('joinRoom should call manager.joinRoom and update state on success', async () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+    managerInstanceInHook.joinRoom.mockResolvedValue(true);
+    managerInstanceInHook.getLocalParticipant.mockReturnValue({ identity: 'local-user' } as Participant);
+
+    let success = false;
+    await act(async () => {
+      success = await result.current.joinRoom('room1', 'user1', 'role1', 'User One');
+    });
+
+    expect(managerInstanceInHook.joinRoom).toHaveBeenCalledWith('room1', 'user1', 'role1', 'User One');
+    expect(success).toBe(true);
+    expect(result.current.currentRoomId).toBe('room1');
+    expect(result.current.localParticipant).toEqual({ identity: 'local-user' });
+  });
+
+  it('joinRoom should handle failure from manager.joinRoom', async () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+    managerInstanceInHook.joinRoom.mockResolvedValue(false);
+    // Simulate onError being called by the manager upon failure
+    const testError = new Error("Join failed in manager");
+    // This requires manager to call its own onError callback
+    // For this test, we assume the manager handles setting its own error state that the hook then picks up
+    // Or, the hook's joinRoom could explicitly set an error if manager.joinRoom returns false and manager.onError wasn't called.
+    // The current hook implementation relies on manager's onError. So, we need to simulate that.
+
+    let success = true;
+    await act(async () => {
+      // Simulate manager calling its onError callback if joinRoom returns false
+      managerInstanceInHook.joinRoom.mockImplementation(async () => {
+        act(() => {
+            managerInstanceInHook.onError(testError);
+        });
+        return false;
+      });
+      success = await result.current.joinRoom('room1', 'user1', 'role1', 'User One');
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe(testError); // Check if error state is updated in the hook
+  });
+
+
+  it('leaveRoom should call manager.leaveRoom and reset state', async () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+    managerInstanceInHook.leaveRoom.mockResolvedValue(undefined);
+
+    // Simulate being in a room first
+    // For this test, we need to call the hook's internal state setters.
+    // This is not ideal but `renderHook` doesn't easily allow setting initial state for useState *within* the hook
+    // when that state is derived from effects.
+    // A more robust way would be to simulate the joinRoom sequence that sets these states.
+    // However, for focused testing of leaveRoom's reset logic:
+    act(() => {
+      // Simulate the state after a successful join
+      // This relies on the manager's callbacks being set up correctly by the hook's useEffect
+      managerInstanceInHook.onConnectionStateChanged(ConnectionState.Connected);
+      managerInstanceInHook.getCurrentRoomId.mockReturnValue('room1'); // Simulate manager state
+      managerInstanceInHook.getLocalParticipant.mockReturnValue({identity: 'local'} as Participant);
+      managerInstanceInHook.onParticipantsChanged([{identity: 'p1'}] as Participant[]);
+    });
+
+    // Verify state before leaving
+    expect(result.current.currentRoomId).toBe('room1');
+    expect(result.current.participants.length).toBe(1);
+    expect(result.current.localParticipant).not.toBeNull();
+
+
+    await act(async () => {
+      await result.current.leaveRoom();
+    });
+
+    expect(managerInstanceInHook.leaveRoom).toHaveBeenCalledTimes(1);
+    expect(result.current.currentRoomId).toBeNull();
+    expect(result.current.participants).toEqual([]);
+    expect(result.current.localParticipant).toBeNull();
+  });
+
+  it('toggleMuteSelf should call manager.toggleMuteSelf', async () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+    managerInstanceInHook.toggleMuteSelf.mockResolvedValue(true);
+
+    let muteResult;
+    await act(async () => {
+      muteResult = await result.current.toggleMuteSelf();
+    });
+
+    expect(managerInstanceInHook.toggleMuteSelf).toHaveBeenCalledTimes(1);
+    expect(muteResult).toBe(true);
+  });
+
+  it('moderateMuteParticipant should call manager.moderateMuteParticipant', async () => {
+    const { result } = renderHook(() => useNewVoiceCollaboration());
+    const managerInstanceInHook = (NewVoiceChatManager as jest.Mock).mock.results[0].value;
+    managerInstanceInHook.moderateMuteParticipant.mockResolvedValue(true);
+
+    let moderateResult = false;
+    await act(async () => {
+      moderateResult = await result.current.moderateMuteParticipant('targetUser', true);
+    });
+
+    expect(managerInstanceInHook.moderateMuteParticipant).toHaveBeenCalledWith('targetUser', true);
+    expect(moderateResult).toBe(true);
+  });
+
+});

--- a/src/hooks/useNewVoiceCollaboration.ts
+++ b/src/hooks/useNewVoiceCollaboration.ts
@@ -1,0 +1,147 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { NewVoiceChatManager } from '@/services/NewVoiceChatManager'; // Adjust path as needed
+import { Participant, ConnectionState, Room } from 'livekit-client'; // Import LiveKit types
+
+// Define interface for room details if not already globally available
+// This should match or be compatible with VoiceRoomDetails from NewVoiceChatManager
+interface UIVoiceRoom {
+  id: string;
+  name: string;
+  // Add any other fields you expect from listAvailableRooms that are relevant to the UI
+}
+
+export interface UseNewVoiceCollaborationReturn {
+  manager: NewVoiceChatManager | null; // Expose manager for advanced use cases if needed
+  availableRooms: UIVoiceRoom[];
+  currentRoomId: string | null;
+  participants: Participant[];
+  localParticipant: Participant | null;
+  connectionState: ConnectionState | null;
+  isConnecting: boolean;
+  isConnected: boolean;
+  isLoadingRooms: boolean;
+  error: Error | null;
+  joinRoom: (roomId: string, userId: string, userRole: string, participantName?: string) => Promise<boolean>;
+  leaveRoom: () => Promise<void>;
+  toggleMuteSelf: () => Promise<boolean | undefined>;
+  fetchAvailableRooms: (matchId: string) => Promise<void>;
+  // Add other wrapped methods from the manager as needed e.g., for moderation
+  moderateMuteParticipant: (targetIdentity: string, mute: boolean) => Promise<boolean>;
+}
+
+export const useNewVoiceCollaboration = (): UseNewVoiceCollaborationReturn => {
+  const [manager, setManager] = useState<NewVoiceChatManager | null>(null);
+  const [availableRooms, setAvailableRooms] = useState<UIVoiceRoom[]>([]);
+  const [currentRoomId, setCurrentRoomId] = useState<string | null>(null);
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [localParticipant, setLocalParticipant] = useState<Participant | null>(null);
+  const [connectionState, setConnectionState] = useState<ConnectionState | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoadingRooms, setIsLoadingRooms] = useState<boolean>(false);
+
+  // Instantiate the manager once
+  useEffect(() => {
+    const voiceManager = new NewVoiceChatManager();
+    setManager(voiceManager);
+
+    // Setup callbacks
+    voiceManager.onParticipantsChanged = (newParticipants) => {
+      setParticipants(newParticipants);
+      setLocalParticipant(voiceManager.getLocalParticipant()); // Keep local participant updated
+    };
+    voiceManager.onConnectionStateChanged = (newState) => {
+      setConnectionState(newState);
+      setCurrentRoomId(voiceManager.getCurrentRoomId()); // Update currentRoomId based on manager's state
+      if (newState === ConnectionState.Connected) {
+        setError(null); // Clear error on successful connection
+      }
+    };
+    voiceManager.onError = (newError) => {
+      console.error('Error from NewVoiceChatManager in hook:', newError);
+      setError(newError);
+    };
+
+    // Cleanup on unmount
+    return () => {
+      voiceManager.dispose();
+      setManager(null);
+    };
+  }, []);
+
+  const fetchAvailableRooms = useCallback(async (matchId: string) => {
+    if (!manager) return;
+    setIsLoadingRooms(true);
+    setError(null);
+    try {
+      const rooms = await manager.listAvailableRooms(matchId);
+      // Map to UIVoiceRoom if needed, assuming VoiceRoomDetails is compatible
+      setAvailableRooms(rooms.map(r => ({ id: r.id, name: r.name })));
+    } catch (e) {
+      setError(e as Error);
+      setAvailableRooms([]);
+    } finally {
+      setIsLoadingRooms(false);
+    }
+  }, [manager]);
+
+  const joinRoom = useCallback(async (roomId: string, userId: string, userRole: string, participantName?: string): Promise<boolean> => {
+    if (!manager) {
+      setError(new Error("Voice chat manager not initialized."));
+      return false;
+    }
+    setError(null);
+    const success = await manager.joinRoom(roomId, userId, userRole, participantName);
+    if (success) {
+      setCurrentRoomId(roomId);
+      setLocalParticipant(manager.getLocalParticipant());
+    } else {
+       // Error should be set by the manager's onError callback
+    }
+    return success;
+  }, [manager]);
+
+  const leaveRoom = useCallback(async () => {
+    if (!manager) return;
+    setError(null);
+    await manager.leaveRoom();
+    setCurrentRoomId(null);
+    setParticipants([]);
+    setLocalParticipant(null);
+    // Connection state should be updated by manager's callback
+  }, [manager]);
+
+  const toggleMuteSelf = useCallback(async (): Promise<boolean | undefined> => {
+    if (!manager) return undefined;
+    return await manager.toggleMuteSelf();
+    // Participant state (isMuted) should update via LiveKit events triggering onParticipantsChanged
+  }, [manager]);
+
+  const moderateMuteParticipant = useCallback(async (targetIdentity: string, mute: boolean): Promise<boolean> => {
+    if (!manager) {
+        setError(new Error("Voice chat manager not initialized."));
+        return false;
+    }
+    return await manager.moderateMuteParticipant(targetIdentity, mute);
+  }, [manager]);
+
+  const isConnecting = useMemo(() => connectionState === ConnectionState.Connecting, [connectionState]);
+  const isConnected = useMemo(() => connectionState === ConnectionState.Connected, [connectionState]);
+
+  return {
+    manager, // Exposing manager might be useful for direct access in some complex components
+    availableRooms,
+    currentRoomId,
+    participants,
+    localParticipant,
+    connectionState,
+    isConnecting,
+    isConnected,
+    isLoadingRooms,
+    error,
+    joinRoom,
+    leaveRoom,
+    toggleMuteSelf,
+    fetchAvailableRooms,
+    moderateMuteParticipant,
+  };
+};

--- a/src/pages/NewVoiceChatPage.tsx
+++ b/src/pages/NewVoiceChatPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { NewVoiceChat } from '@/components/voice/NewVoiceChat'; // Adjust path as needed
+
+const NewVoiceChatPage: React.FC = () => {
+  return (
+    <div>
+      <h1>Voice Chat Test Page</h1>
+      <p>This page hosts the new voice chat component for testing and demonstration.</p>
+      <NewVoiceChat />
+    </div>
+  );
+};
+
+export default NewVoiceChatPage;

--- a/src/services/NewVoiceChatManager.test.ts
+++ b/src/services/NewVoiceChatManager.test.ts
@@ -1,0 +1,253 @@
+import { NewVoiceChatManager } from './NewVoiceChatManager';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Room, ConnectionState, RoomEvent, LocalParticipant, RemoteParticipant } from 'livekit-client';
+
+// Mock Supabase
+jest.mock('@supabase/supabase-js', () => {
+  const mockSupabaseClient = {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({
+        data: { session: { access_token: 'fake-access-token' } },
+        error: null,
+      }),
+    },
+    from: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    functions: {
+      invoke: jest.fn(),
+    },
+  };
+  return {
+    createClient: jest.fn(() => mockSupabaseClient),
+  };
+});
+
+// Mock LiveKit Room
+jest.mock('livekit-client', () => {
+  const originalModule = jest.requireActual('livekit-client');
+  return {
+    ...originalModule,
+    Room: jest.fn().mockImplementation(() => ({
+      on: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      removeAllListeners: jest.fn(),
+      localParticipant: {
+        setMicrophoneEnabled: jest.fn().mockResolvedValue(undefined),
+        isMicrophoneMuted: false,
+        identity: 'local-user-identity',
+        name: 'Local User',
+      } as unknown as LocalParticipant, // Cast to satisfy type, add more props if needed
+      remoteParticipants: new Map<string, RemoteParticipant>(),
+      state: ConnectionState.Disconnected,
+    })),
+  };
+});
+
+
+describe('NewVoiceChatManager', () => {
+  let voiceManager: NewVoiceChatManager;
+  let mockSupabaseInstance: any; // Type properly if you have a mock type
+  let mockLiveKitRoomInstance: jest.Mocked<Room>;
+
+  beforeEach(() => {
+    // Reset mocks for Supabase client before each test
+    const { createClient } = require('@supabase/supabase-js');
+    mockSupabaseInstance = createClient(); // Get the mocked instance
+
+    // Reset specific function mocks on the Supabase instance
+    mockSupabaseInstance.auth.getSession.mockResolvedValue({
+        data: { session: { access_token: 'fake-access-token' } },
+        error: null,
+    });
+    mockSupabaseInstance.from.mockReturnThis(); // Ensure chaining works
+    mockSupabaseInstance.select.mockReturnThis();
+    mockSupabaseInstance.eq.mockReturnThis();
+    mockSupabaseInstance.order.mockReturnThis();
+    mockSupabaseInstance.functions.invoke.mockReset(); // Reset invoke specifically
+
+    voiceManager = new NewVoiceChatManager();
+
+    // Get the latest mock LiveKit Room instance after manager instantiation (if needed)
+    // This assumes NewVoiceChatManager creates a Room instance internally upon certain actions.
+    // For now, we'll mock the constructor, so any `new Room()` will use the mock.
+    const { Room: MockedRoom } = require('livekit-client');
+    // If the Room is created on join, this might need to be accessed after joinRoom is called
+    // For now, we assume the mock setup for `new Room()` is sufficient.
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    voiceManager.dispose(); // Clean up manager resources
+  });
+
+  describe('Constructor and Initialization', () => {
+    it('should initialize Supabase client', () => {
+      const { createClient } = require('@supabase/supabase-js');
+      expect(createClient).toHaveBeenCalledWith(import.meta.env.VITE_SUPABASE_URL, import.meta.env.VITE_SUPABASE_ANON_KEY);
+    });
+  });
+
+  describe('listAvailableRooms', () => {
+    it('should fetch and return available rooms for a matchId', async () => {
+      const mockRooms = [{ id: 'room1', name: 'Room 1', match_id: 'match1', is_active: true }];
+      mockSupabaseInstance.from('voice_rooms').select('*').eq('match_id', 'match1').eq('is_active', true).order('priority').mockResolvedValueOnce({ data: mockRooms, error: null });
+
+      const rooms = await voiceManager.listAvailableRooms('match1');
+      expect(rooms).toEqual(mockRooms);
+      expect(mockSupabaseInstance.from).toHaveBeenCalledWith('voice_rooms');
+      expect(mockSupabaseInstance.select).toHaveBeenCalledWith('*');
+      expect(mockSupabaseInstance.eq).toHaveBeenCalledWith('match_id', 'match1');
+      expect(mockSupabaseInstance.eq).toHaveBeenCalledWith('is_active', true);
+    });
+
+    it('should return empty array on error when fetching rooms', async () => {
+      mockSupabaseInstance.from('voice_rooms').select('*').eq('match_id', 'match1').eq('is_active', true).order('priority').mockResolvedValueOnce({ data: null, error: new Error('DB Error') });
+      const onErrorCallback = jest.fn();
+      voiceManager.onError = onErrorCallback;
+
+      const rooms = await voiceManager.listAvailableRooms('match1');
+      expect(rooms).toEqual([]);
+      expect(onErrorCallback).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  describe('joinRoom', () => {
+    beforeEach(() => {
+      // Setup default successful responses for dependent functions
+      mockSupabaseInstance.functions.invoke
+        .mockResolvedValueOnce({ data: { authorized: true, message: 'Joined' }, error: null }) // for join-voice-room
+        .mockResolvedValueOnce({ data: { token: 'fake-livekit-token' }, error: null }); // for generate-livekit-token
+
+      // Ensure VITE_LIVEKIT_URL is set for tests
+      process.env.VITE_LIVEKIT_URL = 'wss://fake-livekit-url.com';
+    });
+
+    it('should successfully join a room, connect to LiveKit and enable microphone', async () => {
+      const result = await voiceManager.joinRoom('room1', 'user1', 'tracker', 'User One');
+
+      expect(result).toBe(true);
+      expect(mockSupabaseInstance.functions.invoke).toHaveBeenCalledWith('join-voice-room', {
+        body: { roomId: 'room1', userId: 'user1', userRole: 'tracker' },
+        headers: { Authorization: 'Bearer fake-access-token' },
+      });
+      expect(mockSupabaseInstance.functions.invoke).toHaveBeenCalledWith('generate-livekit-token', {
+        body: { roomId: 'room1', participantIdentity: 'user1', participantName: 'User One' },
+        headers: { Authorization: 'Bearer fake-access-token' },
+      });
+
+      // Access the actual mock instance created by `new Room()`
+      // This requires the mock for `livekit-client`'s Room constructor to be effective.
+      // The instance is created inside joinRoom. We need to check the mock on the `Room` constructor.
+      const { Room: MockedRoomConstructor } = require('livekit-client');
+      const mockRoomInstance = MockedRoomConstructor.mock.results[0]?.value; // Get the first instance created
+
+      expect(MockedRoomConstructor).toHaveBeenCalledTimes(1);
+      expect(mockRoomInstance.connect).toHaveBeenCalledWith('wss://fake-livekit-url.com', 'fake-livekit-token', { autoSubscribe: true });
+      expect(mockRoomInstance.localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true);
+      expect(voiceManager.getCurrentRoomId()).toBe('room1');
+    });
+
+    it('should return false if join-voice-room fails', async () => {
+      mockSupabaseInstance.functions.invoke
+        .mockReset() // Reset previous mock setup for this specific test
+        .mockResolvedValueOnce({ data: { authorized: false, error: 'Not allowed' }, error: null }); // join-voice-room fails
+
+      const onErrorCallback = jest.fn();
+      voiceManager.onError = onErrorCallback;
+
+      const result = await voiceManager.joinRoom('room1', 'user1', 'tracker');
+      expect(result).toBe(false);
+      expect(onErrorCallback).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('Join room authorization step failed: Not allowed') }));
+      expect(voiceManager.getCurrentRoomId()).toBeNull();
+    });
+
+    it('should return false if generate-livekit-token fails', async () => {
+      mockSupabaseInstance.functions.invoke
+        .mockReset()
+        .mockResolvedValueOnce({ data: { authorized: true }, error: null }) // join-voice-room success
+        .mockResolvedValueOnce({ data: { token: null, error: 'Token gen error' }, error: null }); // generate-livekit-token fails
+
+      const onErrorCallback = jest.fn();
+      voiceManager.onError = onErrorCallback;
+
+      const result = await voiceManager.joinRoom('room1', 'user1', 'tracker');
+      expect(result).toBe(false);
+      expect(onErrorCallback).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('LiveKit token generation failed: Token gen error') }));
+      expect(voiceManager.getCurrentRoomId()).toBeNull();
+    });
+
+    it('should return false if LiveKit URL is not configured', async () => {
+      delete process.env.VITE_LIVEKIT_URL; // Simulate missing env var
+      const onErrorCallback = jest.fn();
+      voiceManager.onError = onErrorCallback;
+
+      const result = await voiceManager.joinRoom('room1', 'user1', 'tracker');
+      expect(result).toBe(false);
+      expect(onErrorCallback).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('LiveKit URL is not configured')}));
+    });
+
+  });
+
+  describe('leaveRoom', () => {
+    it('should disconnect from LiveKit room and clean up', async () => {
+      // First, join a room to have a liveKitRoom instance
+      mockSupabaseInstance.functions.invoke
+        .mockResolvedValueOnce({ data: { authorized: true }, error: null })
+        .mockResolvedValueOnce({ data: { token: 'fake-livekit-token' }, error: null });
+      process.env.VITE_LIVEKIT_URL = 'wss://fake-livekit-url.com';
+      await voiceManager.joinRoom('room1', 'user1', 'tracker');
+
+      const { Room: MockedRoomConstructor } = require('livekit-client');
+      const mockRoomInstance = MockedRoomConstructor.mock.results[0]?.value;
+
+      const onConnStateChange = jest.fn();
+      voiceManager.onConnectionStateChanged = onConnStateChange;
+
+      await voiceManager.leaveRoom();
+
+      expect(mockRoomInstance.disconnect).toHaveBeenCalled();
+      expect(mockRoomInstance.removeAllListeners).toHaveBeenCalled();
+      expect(voiceManager.getCurrentRoomId()).toBeNull();
+      // Check if onConnectionStateChanged was called with Disconnected
+      // This depends on exact implementation, might be called from within leaveRoom or by LiveKit events
+      // For this test, let's assume leaveRoom calls it directly or indirectly
+      expect(onConnStateChange).toHaveBeenCalledWith(ConnectionState.Disconnected);
+    });
+  });
+
+  describe('toggleMuteSelf', () => {
+    it('should toggle microphone state if connected', async () => {
+      // Join room first
+      mockSupabaseInstance.functions.invoke
+        .mockResolvedValueOnce({ data: { authorized: true }, error: null })
+        .mockResolvedValueOnce({ data: { token: 'fake-livekit-token' }, error: null });
+      process.env.VITE_LIVEKIT_URL = 'wss://fake-livekit-url.com';
+      await voiceManager.joinRoom('room1', 'user1', 'tracker');
+
+      const { Room: MockedRoomConstructor } = require('livekit-client');
+      const mockRoomInstance = MockedRoomConstructor.mock.results[0]?.value;
+
+      // Assume starts unmuted (false)
+      mockRoomInstance.localParticipant.isMicrophoneMuted = false;
+      let mutedState = await voiceManager.toggleMuteSelf();
+      expect(mutedState).toBe(true); // Should now be muted
+      expect(mockRoomInstance.localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(false); // Enabled(false) means muted
+
+      mockRoomInstance.localParticipant.isMicrophoneMuted = true; // Simulate it's now muted
+      mutedState = await voiceManager.toggleMuteSelf();
+      expect(mutedState).toBe(false); // Should now be unmuted
+      expect(mockRoomInstance.localParticipant.setMicrophoneEnabled).toHaveBeenCalledWith(true); // Enabled(true) means unmuted
+    });
+
+    it('should return undefined if not connected', async () => {
+      const result = await voiceManager.toggleMuteSelf();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // TODO: Add tests for moderateMuteParticipant, dispose, and event handlers (onParticipantsChanged, etc.)
+  // For event handlers, you would need to simulate LiveKit emitting events on the mocked Room instance.
+});

--- a/src/services/NewVoiceChatManager.ts
+++ b/src/services/NewVoiceChatManager.ts
@@ -1,0 +1,293 @@
+import { Room, RoomEvent, RemoteParticipant, Participant, ConnectionState } from 'livekit-client';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { Database } from '@/lib/database.types'; // Assuming this path is correct
+
+// Environment variables (ensure these are set in your .env file)
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+interface VoiceRoomDetails {
+  id: string;
+  name: string;
+  max_participants?: number;
+  // Add other relevant fields from your voice_rooms table
+}
+
+// interface ParticipantDetails { // This interface is not actively used in the current service implementation
+//   id: string;
+//   user_id: string;
+//   user_role: string;
+//   is_muted?: boolean;
+//   is_speaking?: boolean;
+//   // Add other relevant fields from your voice_room_participants table
+// }
+
+export class NewVoiceChatManager {
+  private supabase: SupabaseClient<Database>;
+  private liveKitRoom: Room | null = null;
+  private currentRoomId: string | null = null;
+  private localParticipantName: string | null = null;
+  private localParticipantIdentity: string | null = null;
+
+  // Callbacks for UI updates
+  public onParticipantsChanged: ((participants: Participant[]) => void) | null = null;
+  public onConnectionStateChanged: ((state: ConnectionState) => void) | null = null;
+  public onError: ((error: Error) => void) | null = null;
+
+  constructor() {
+    if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+      throw new Error('Supabase URL or Anon Key is not defined. Please check your environment variables.');
+    }
+    this.supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
+  }
+
+  private async getAuthToken(): Promise<string | null> {
+    const { data: { session }, error } = await this.supabase.auth.getSession();
+    if (error || !session) {
+      this.handleError(new Error(`Error fetching session or no active session: ${error?.message}`));
+      return null;
+    }
+    return session.access_token;
+  }
+
+  private handleError(error: Error, message?: string): void {
+    const errorMessage = message ? `${message} ${error.message}` : `NewVoiceChatManager Error: ${error.message}`;
+    console.error(errorMessage, error);
+    if (this.onError) {
+      this.onError(new Error(errorMessage)); // Pass a new error object with the combined message
+    }
+  }
+
+  public async listAvailableRooms(matchId: string): Promise<VoiceRoomDetails[]> {
+    const authToken = await this.getAuthToken();
+    if (!authToken) {
+        this.handleError(new Error('Authentication token not available for listAvailableRooms.'));
+        return [];
+    }
+
+    try {
+      // Note: RLS policies on 'voice_rooms' should handle whether the user can see these rooms.
+      // The authToken is implicitly used by the Supabase client instance if configured globally,
+      // but for functions, explicit header passing is safer. For table access, RLS is key.
+      const { data, error } = await this.supabase
+        .from('voice_rooms')
+        .select('*')
+        .eq('match_id', matchId)
+        .eq('is_active', true)
+        .order('priority', { ascending: true });
+
+      if (error) {
+        this.handleError(error, `Error fetching rooms for match ${matchId}:`);
+        return [];
+      }
+      return data || [];
+    } catch (err) {
+      this.handleError(err as Error, `Unexpected error fetching rooms for match ${matchId}:`);
+      return [];
+    }
+  }
+
+  public async joinRoom(roomId: string, userId: string, userRole: string, participantName?: string): Promise<boolean> {
+    if (this.liveKitRoom && this.currentRoomId === roomId) {
+      console.warn('Already connected to this room.');
+      return true;
+    }
+
+    await this.leaveRoom();
+
+    this.currentRoomId = roomId;
+    this.localParticipantIdentity = userId;
+    this.localParticipantName = participantName || userId;
+
+    const authToken = await this.getAuthToken();
+    if (!authToken) {
+        this.handleError(new Error('Authentication token not available for joinRoom.'));
+        this.currentRoomId = null; // Reset since we can't proceed
+        return false;
+    }
+
+    try {
+      const { data: joinData, error: joinError } = await this.supabase.functions.invoke('join-voice-room', {
+        body: { roomId, userId, userRole },
+        headers: { Authorization: `Bearer ${authToken}` }
+      });
+
+      // Ensure joinData.error is checked if joinData itself is not null
+      if (joinError || (joinData && (joinData as any).error) || !(joinData as any)?.authorized) {
+        const message = joinError?.message || (joinData as any)?.error || 'Failed to authorize room entry.';
+        this.handleError(new Error(message), 'Join room authorization step failed:');
+        this.currentRoomId = null;
+        return false;
+      }
+      console.log('Successfully authorized and logged in voice_room_participants:', joinData);
+
+      const { data: tokenData, error: tokenError } = await this.supabase.functions.invoke('generate-livekit-token', {
+        body: {
+          roomId,
+          participantIdentity: this.localParticipantIdentity,
+          participantName: this.localParticipantName,
+        },
+        headers: { Authorization: `Bearer ${authToken}` }
+      });
+
+      if (tokenError || (tokenData && (tokenData as any).error) || !(tokenData as any)?.token) {
+        const message = tokenError?.message || (tokenData as any)?.error || 'Failed to get LiveKit token.';
+        this.handleError(new Error(message), 'LiveKit token generation failed:');
+        this.currentRoomId = null;
+        return false;
+      }
+      const liveKitToken = (tokenData as any).token;
+
+      this.liveKitRoom = new Room();
+      this.liveKitRoom.on(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChange);
+      this.liveKitRoom.on(RoomEvent.ParticipantConnected, this.handleParticipantChange);
+      this.liveKitRoom.on(RoomEvent.ParticipantDisconnected, this.handleParticipantChange);
+      this.liveKitRoom.on(RoomEvent.LocalTrackPublished, this.handleParticipantChange);
+      this.liveKitRoom.on(RoomEvent.LocalTrackUnpublished, this.handleParticipantChange);
+      this.liveKitRoom.on(RoomEvent.TrackSubscribed, this.handleParticipantChange); // For remote tracks
+      this.liveKitRoom.on(RoomEvent.TrackUnsubscribed, this.handleParticipantChange); // For remote tracks
+      this.liveKitRoom.on(RoomEvent.TrackMuted, this.handleParticipantChange);
+      this.liveKitRoom.on(RoomEvent.TrackUnmuted, this.handleParticipantChange);
+      this.liveKitRoom.on(RoomEvent.ActiveSpeakersChanged, this.handleParticipantChange);
+
+
+      const LIVEKIT_URL = import.meta.env.VITE_LIVEKIT_URL;
+      if (!LIVEKIT_URL) {
+        this.handleError(new Error('LiveKit URL is not configured in environment variables (VITE_LIVEKIT_URL).'));
+        this.currentRoomId = null;
+        return false;
+      }
+
+      await this.liveKitRoom.connect(LIVEKIT_URL, liveKitToken, { autoSubscribe: true });
+      await this.liveKitRoom.localParticipant.setMicrophoneEnabled(true);
+
+      console.log(`Successfully connected to LiveKit room: ${roomId}`);
+      if (this.onConnectionStateChanged) {
+        this.onConnectionStateChanged(this.liveKitRoom.state);
+      }
+      this.updateParticipants();
+      return true;
+
+    } catch (err) {
+      this.handleError(err as Error, `Error joining room ${roomId}:`);
+      await this.leaveRoom();
+      return false;
+    }
+  }
+
+  private handleConnectionStateChange = (state: ConnectionState) => {
+    console.log('LiveKit Connection State:', state);
+    if (this.onConnectionStateChanged) {
+      this.onConnectionStateChanged(state);
+    }
+    if (state === ConnectionState.Disconnected) {
+      // Consider whether to attempt reconnection or just clean up
+      console.log('Disconnected from LiveKit. Cleaning up.');
+      this.liveKitRoom?.removeAllListeners(); // Clean up listeners on the old room object
+      this.liveKitRoom = null;
+      this.currentRoomId = null; // Potentially reset currentRoomId if disconnect means "left the room"
+      this.updateParticipants();
+    }
+  }
+
+  private handleParticipantChange = () => { // Removed unused parameters
+    this.updateParticipants();
+  }
+
+  private updateParticipants() {
+    if (this.onParticipantsChanged) {
+      if (this.liveKitRoom) {
+        const participants = [
+          this.liveKitRoom.localParticipant,
+          ...Array.from(this.liveKitRoom.remoteParticipants.values()),
+        ];
+        this.onParticipantsChanged(participants);
+      } else {
+        this.onParticipantsChanged([]); // Send empty array if room is null
+      }
+    }
+  }
+
+  public async leaveRoom(): Promise<void> {
+    if (this.liveKitRoom) {
+      console.log('Leaving LiveKit room:', this.currentRoomId);
+      await this.liveKitRoom.disconnect();
+      this.liveKitRoom.removeAllListeners();
+      this.liveKitRoom = null;
+      // currentRoomId is reset in handleConnectionStateChange or here if preferred
+      // this.currentRoomId = null;
+      console.log('Disconnected from LiveKit room.');
+      // Manually trigger state update if not handled by ConnectionState.Disconnected
+      if (this.onConnectionStateChanged && this.currentRoomId !== null) { // Avoid double-trigger if already disconnected
+         this.onConnectionStateChanged(ConnectionState.Disconnected);
+      }
+      this.currentRoomId = null; // Ensure it's nulled after potential callback
+      this.updateParticipants(); // Ensure UI clears participants
+    }
+  }
+
+  public async toggleMuteSelf(): Promise<boolean | undefined> {
+    if (this.liveKitRoom && this.liveKitRoom.localParticipant && this.liveKitRoom.localParticipant.microphoneTrack) {
+      const isMuted = this.liveKitRoom.localParticipant.isMicrophoneMuted;
+      await this.liveKitRoom.localParticipant.setMicrophoneEnabled(!isMuted);
+      // No need to call updateParticipants() here if TrackMuted/Unmuted events are handled
+      return !isMuted;
+    }
+    console.warn('Cannot toggle mute: No local participant or microphone track.');
+    return undefined;
+  }
+
+  public getLocalParticipant(): Participant | null {
+    return this.liveKitRoom?.localParticipant || null;
+  }
+
+  public getRemoteParticipants(): RemoteParticipant[] { // Return array for easier use
+    return this.liveKitRoom ? Array.from(this.liveKitRoom.remoteParticipants.values()) : [];
+  }
+
+  public getCurrentRoomId(): string | null {
+    return this.currentRoomId;
+  }
+
+  public async moderateMuteParticipant(targetIdentity: string, mute: boolean): Promise<boolean> {
+    if (!this.currentRoomId) {
+      this.handleError(new Error('Not connected to a room to moderate.'));
+      return false;
+    }
+    const authToken = await this.getAuthToken();
+    if (!authToken) {
+        this.handleError(new Error('Authentication token not available for moderateMuteParticipant.'));
+        return false;
+    }
+
+    try {
+      const { data, error } = await this.supabase.functions.invoke('moderate-livekit-room', {
+        body: {
+          roomId: this.currentRoomId,
+          targetIdentity,
+          mute,
+        },
+        headers: { Authorization: `Bearer ${authToken}` }
+      });
+
+      if (error || (data && (data as any).error)) {
+        const message = error?.message || (data as any)?.error || 'Failed to moderate participant.';
+        this.handleError(new Error(message), 'Moderation action failed:');
+        return false;
+      }
+      console.log(`Moderation action successful for ${targetIdentity}: ${(data as any).message}`);
+      return true;
+    } catch (err) {
+      this.handleError(err as Error, `Error moderating participant ${targetIdentity}:`);
+      return false;
+    }
+  }
+
+  public dispose(): void {
+    console.log('Disposing NewVoiceChatManager.');
+    this.leaveRoom(); // Ensure room is left and listeners cleaned up
+    this.onParticipantsChanged = null;
+    this.onConnectionStateChanged = null;
+    this.onError = null;
+  }
+}


### PR DESCRIPTION
This commit introduces a new voice chat collaboration system.

Key components include:
- **NewVoiceChatManager (service):** Manages LiveKit room connections, interacts with Supabase for room data and authorization (reusing existing Supabase functions like 'join-voice-room' and 'generate-livekit-token').
- **useNewVoiceCollaboration (hook):** Provides a React hook to easily integrate voice chat functionality into components, managing state for rooms, participants, connection status, and errors.
- **NewVoiceChat (component):** A new UI component allowing you to view available rooms, join/leave rooms, see participants with their status (muted/speaking), and control your own microphone.
- **NewVoiceChatPage (page):** A dedicated page (`/new-voice-chat`) to host and demonstrate the new voice chat component.

The implementation leverages existing Supabase tables (`voice_rooms`, `voice_room_participants`) and associated RLS policies.

Testing:
- Unit/integration tests have been added for the `NewVoiceChatManager` service, covering core logic like room joining, listing, and LiveKit interactions.
- Tests for the `useNewVoiceCollaboration` hook verify state management and interaction with the underlying service.
- Component tests for `NewVoiceChat` ensure correct rendering based on state and proper handling of your interactions.

This feature provides a foundation for enhanced voice collaboration capabilities within the application.