### PR TITLE
fix: Address build errors from voice chat implementation

### DIFF
--- a/src/pages/NewVoiceChatPage.tsx
+++ b/src/pages/NewVoiceChatPage.tsx
@@ -6,7 +6,7 @@ import { CircularProgress } from '@mui/material'; // Assuming MUI is used for pr
 
 const NewVoiceChatPage: React.FC = () => {
   const { matchId } = useParams<{ matchId: string }>();
-  const { user, userRole, loading: authLoading, user?.user_metadata } = useAuth(); // Destructure user_metadata
+  const { user, userRole, loading: authLoading } = useAuth(); // Corrected destructuring
 
   if (authLoading) {
     return (


### PR DESCRIPTION
This commit fixes two issues that were causing build failures:

1.  **Duplicate 'setError' declaration in `src/hooks/useVoiceCollaboration.ts`:** The error log indicated a duplicate `setError` function. I removed the duplicate `useCallback`-wrapped `setError`, and standardized the error state type to `Error | null` using the `setError` from `useState`.

2.  **Syntax error in `src/pages/NewVoiceChatPage.tsx`:** I corrected an issue where optional chaining (`?.`) was incorrectly used within a destructuring assignment for `user_metadata` when calling `useAuth()`. I updated the destructuring to correctly extract the `user` object first, and then access `user_metadata` with optional chaining.

These changes should resolve the reported build errors. This work is part of the effort to make the new voice chat feature production-ready.