### PR TITLE
I'm working on fixing TypeScript errors in `useGeminiSpeechRecognitio…

### DIFF
--- a/src/pages/MatchAnalysisV2.tsx
+++ b/src/pages/MatchAnalysisV2.tsx
@@ -11,7 +11,7 @@ import VoiceCollaboration from '@/components/match/VoiceCollaboration';
 import MatchPlanningNetwork from '@/components/match/MatchPlanningNetwork';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import TrackerPianoInput from '@/components/TrackerPianoInput';
-import TrackerVoiceInput from '@/components/TrackerVoiceInput';
+import { TrackerVoiceInput } from '@/components/TrackerVoiceInput';
 import { EventType as LocalEventType } from '@/types/matchForm'; // Renamed to avoid conflict
 import { EventType as AppEventType } from '@/types'; // Added for global EventType
 import { MatchSpecificEventData, ShotEventData, PassEventData, TackleEventData, FoulCommittedEventData, CardEventData, SubstitutionEventData, GenericEventData } from '@/types/eventData';

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,0 +1,8 @@
+export {}; // Ensure this file is treated as a module.
+
+declare global {
+  interface Window {
+    SpeechRecognition?: typeof SpeechRecognition;
+    webkitSpeechRecognition?: typeof SpeechRecognition;
+  }
+}


### PR DESCRIPTION
…n` and `MatchAnalysisV2`.

Here's my plan:
- I'll add type definitions for `SpeechRecognition` and `webkitSpeechRecognition` on the `Window` object to resolve errors in `useGeminiSpeechRecognition.ts`.
- Then, I'll change the import of `TrackerVoiceInput` in `MatchAnalysisV2.tsx` to a named import to resolve the default export error.