### PR TITLE
fix(useUnifiedTrackerConnection): Reduce excessive initialization log…

### DIFF
--- a/src/hooks/useUnifiedTrackerConnection.ts
+++ b/src/hooks/useUnifiedTrackerConnection.ts
@@ -28,8 +28,6 @@ export const useUnifiedTrackerConnection = (matchId: string, userId?: string) =>
   const channelRef = useRef<any>(null);
   const isCurrentUser = Boolean(userId);
 
-  console.log('UnifiedTrackerConnection: Initialize', { matchId, userId, isCurrentUser });
-
   // Initialize unified channel
   useEffect(() => {
     if (!matchId) {
@@ -38,6 +36,7 @@ export const useUnifiedTrackerConnection = (matchId: string, userId?: string) =>
     }
 
     const initializeChannel = async () => {
+      console.log('UnifiedTrackerConnection: Initialize (attempting channel setup)', { matchId, userId, isCurrentUser });
       try {
         console.log('UnifiedTrackerConnection: Setting up unified channel for match:', matchId);
         


### PR DESCRIPTION
…ging

Moves the 'UnifiedTrackerConnection: Initialize' console.log statement inside the main useEffect hook responsible for channel setup.

Previously, this log statement was outside any effect, causing it to fire on every render of components using the `useUnifiedTrackerConnection` hook.

By placing it within the useEffect (which has dependencies `[matchId, userId, isCurrentUser]`), the log will now only occur when the channel initialization logic is actually triggered due to component mount or changes in these core dependencies. This significantly reduces console noise and correctly reflects when initialization is attempted.