### PR TITLE
This commit introduces minor user experience improvements to the "Mat…

### DIFF
--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -40,8 +40,11 @@
       <hr>
       <h3>Track Match Activity</h3>
       <div class="input-group">
-        <label for="userProvidedMatchId">App Match ID:</label>
-        <input type="text" id="userProvidedMatchId" placeholder="Paste Match ID from main app">
+        <label for="userProvidedMatchId">Enter Live Match Code:</label>
+        <input type="text" id="userProvidedMatchId" placeholder="Paste code from match page">
+        <p class="help-text" style="font-size: 0.8em; color: #666; margin-top: 4px;">
+          You can find this code on the main application's match page. It's used to link your tracking to the correct live match.
+        </p>
       </div>
       <button id="startMatchTrackingBtn" class="btn primary">Start Live Tracking</button>
       <p id="matchTrackingError" class="error-message" style="display:none;"></p>


### PR DESCRIPTION
…ch ID" input field in the Chrome extension's popup (`popup.html`).

Changes include:
- Relabeling "Match ID" to the more user-friendly "Enter Live Match Code:".
- Adding placeholder text ("Paste code from match page") to the input field to guide you.
- Including a descriptive help text paragraph below the input field, explaining where to find the code and its purpose.

These changes aim to make the manual entry of the match identifier slightly clearer and less intimidating for non-technical users, acknowledging that a more integrated solution (like selecting from a list or auto-detection) would be a valuable future enhancement.