### PR TITLE
feat: Integrate video URL setup into CreateMatchForm

### DIFF
--- a/src/components/admin/VideoMatchSetup.tsx
+++ b/src/components/admin/VideoMatchSetup.tsx
@@ -16,8 +16,33 @@ interface EventType {
   name: string;
 }
 
-const VideoMatchSetup: React.FC = () => {
-  const [videoUrl, setVideoUrl] = useState('');
+interface VideoMatchSetupProps {
+  simplifiedView?: boolean;
+  initialVideoUrl?: string;
+  onVideoUrlChange?: (url: string) => void;
+  // Add onSubmit for simplified view if needed, or let CreateMatchForm handle it.
+}
+
+const VideoMatchSetup: React.FC<VideoMatchSetupProps> = ({
+  simplifiedView = false,
+  initialVideoUrl = '',
+  onVideoUrlChange,
+}) => {
+  const [videoUrl, setVideoUrl] = useState(initialVideoUrl);
+
+  // Effect to keep internal state in sync with prop, and notify parent
+  useEffect(() => {
+    setVideoUrl(initialVideoUrl);
+  }, [initialVideoUrl]);
+
+  const handleVideoUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newUrl = e.target.value;
+    setVideoUrl(newUrl);
+    if (onVideoUrlChange) {
+      onVideoUrlChange(newUrl);
+    }
+  };
+
   const [selectedMatch, setSelectedMatch] = useState<string | null>(null);
   const [assignedTrackers, setAssignedTrackers] = useState<string[]>([]);
   const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
@@ -39,63 +64,80 @@ const VideoMatchSetup: React.FC = () => {
 
   return (
     <div>
-      <h3>Video Match Setup</h3>
+      {!simplifiedView && <h3>Video Match Setup</h3>}
       <div>
-        <label>YouTube Video URL:</label>
-        <input type="text" value={videoUrl} onChange={(e) => setVideoUrl(e.target.value)} />
+        <label htmlFor="videoUrlInput">YouTube Video URL:</label>
+        <input
+          id="videoUrlInput"
+          type="text"
+          value={videoUrl}
+          onChange={handleVideoUrlChange}
+          placeholder="e.g., https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+          className="w-full p-2 border rounded" // Example styling
+        />
       </div>
-      <div>
-        <label>Select Match:</label>
-        <select onChange={(e) => setSelectedMatch(e.target.value)} value={selectedMatch || ''}>
-          <option value="" disabled>Select a match</option>
-          {matches.map(match => (
-            <option key={match.id} value={match.id}>{match.name}</option>
-          ))}
-        </select>
-      </div>
-      <div>
-        <label>Assign Trackers:</label>
-        {/* Replace with a multi-select component */}
-        {trackers.map(tracker => (
-          <div key={tracker.id}>
-            <input
-              type="checkbox"
-              id={`tracker-${tracker.id}`}
-              value={tracker.id}
-              onChange={(e) => {
-                if (e.target.checked) {
-                  setAssignedTrackers([...assignedTrackers, tracker.id]);
-                } else {
-                  setAssignedTrackers(assignedTrackers.filter(id => id !== tracker.id));
-                }
-              }}
-            />
-            <label htmlFor={`tracker-${tracker.id}`}>{tracker.name}</label>
+
+      {!simplifiedView && (
+        <>
+          <div className="mt-4">
+            <label>Select Match:</label>
+            <select onChange={(e) => setSelectedMatch(e.target.value)} value={selectedMatch || ''} className="w-full p-2 border rounded">
+              <option value="" disabled>Select a match</option>
+              {matches.map(match => (
+                <option key={match.id} value={match.id}>{match.name}</option>
+              ))}
+            </select>
           </div>
-        ))}
-      </div>
-      <div>
-        <label>Select Events:</label>
-        {/* Replace with a multi-select component */}
-        {eventTypes.map(event => (
-          <div key={event.id}>
-            <input
-              type="checkbox"
-              id={`event-${event.id}`}
-              value={event.id}
-              onChange={(e) => {
-                if (e.target.checked) {
-                  setSelectedEvents([...selectedEvents, event.id]);
-                } else {
-                  setSelectedEvents(selectedEvents.filter(id => id !== event.id));
-                }
-              }}
-            />
-            <label htmlFor={`event-${event.id}`}>{event.name}</label>
+          <div className="mt-4">
+            <label>Assign Trackers:</label>
+            {/* Replace with a multi-select component */}
+            {trackers.map(tracker => (
+              <div key={tracker.id}>
+                <input
+                  type="checkbox"
+                  id={`tracker-${tracker.id}`}
+                  value={tracker.id}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setAssignedTrackers([...assignedTrackers, tracker.id]);
+                    } else {
+                      setAssignedTrackers(assignedTrackers.filter(id => id !== tracker.id));
+                    }
+                  }}
+                />
+                <label htmlFor={`tracker-${tracker.id}`}>{tracker.name}</label>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-      <button onClick={handleSubmit}>Save Setup & Notify Trackers</button>
+          <div className="mt-4">
+            <label>Select Events:</label>
+            {/* Replace with a multi-select component */}
+            {eventTypes.map(event => (
+              <div key={event.id}>
+                <input
+                  type="checkbox"
+                  id={`event-${event.id}`}
+                  value={event.id}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setSelectedEvents([...selectedEvents, event.id]);
+                    } else {
+                      setSelectedEvents(selectedEvents.filter(id => id !== event.id));
+                    }
+                  }}
+                />
+                <label htmlFor={`event-${event.id}`}>{event.name}</label>
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={handleSubmit}
+            className="mt-4 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" // Example styling
+          >
+            Save Full Setup & Notify Trackers
+          </button>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Allows admins to add a YouTube video URL directly when creating or editing a match. The video URL is saved and linked to the match, and assigned trackers are notified that a video is available.

- VideoMatchSetup.tsx updated with a simplifiedView for this context.
- CreateMatchForm.tsx now manages video URL state and calls YouTubeService.addVideoToMatch in handleSubmit.
- Notifications are triggered to assigned trackers about the new video.